### PR TITLE
Changed static hardcoded description and title to envs

### DIFF
--- a/docs.ts
+++ b/docs.ts
@@ -8,9 +8,9 @@ export class DocumentationManager {
         definition: {
             openapi: "3.0.0",
             info: {
-                title: "Server-Users API",
+                title: process.env.DOC_TITLE,
                 version: "1.0.0",
-                description: "Aplicacion que sirve la autenticación y administración de usuarios"
+                description: process.env.DOC_DESCRIPTION
             },
             servers: [{
                 url: process.env.SERVER_URL_DOCS


### PR DESCRIPTION
Depende de que se agreguen las constantes:
DOC_TITLE y DOC_DESCRIPTION a los .env que estamos usando.

Ejemplo para la aplicación de web-service:
DOC_TITLE="Server-Web-Service API"
DOC_DESCRIPTION="Aplicacion que atiende las requests del cliente web"