### PR TITLE
CD-709 - Fecha incorrecta en el correo de aviso de nuevo turno

### DIFF
--- a/email.ts
+++ b/email.ts
@@ -143,7 +143,7 @@ export class EmailAppointment extends Email {
                                     <td style="padding:5%;color:#707070;font-family:Arial;font-size:11pt;border-spacing:0px;background-color:#F1F5F8;"
                                         valign="top">
                                         <p> Hola ${fullName}: </p>
-                                        <p> Tenes un nuevo turno asignado el dia ${appointment.date.toLocaleDateString()} a las ${appointment.date.toLocaleTimeString()} </p>
+                                        <p> Tenes un nuevo turno asignado el dia ${appointment.date.toLocaleDateString('es-AR')} a las ${appointment.date.toLocaleTimeString('es-AR')} </p>
                                     </td>
                                 </tr>
                                 <tr>


### PR DESCRIPTION
https://cie-unlam.atlassian.net/browse/CD-709

Se agregó localizacion es-AR a toLocaleDateString y toLocaleTimeString en el email de creación de turno.
Se usó la misma localización que en notifications.ts en la notificación de recordatorio de turno.